### PR TITLE
sbt 0.12.0 support. for issue #12

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/src/main/scala/cc/spray/revolver/RevolverPlugin.scala
+++ b/src/main/scala/cc/spray/revolver/RevolverPlugin.scala
@@ -49,7 +49,7 @@ object RevolverPlugin extends Plugin {
       reJRebelJar in Global := Option(System.getenv("JREBEL_PATH")).getOrElse(""),
 
       // bake JRebel activation into java options for the forked JVM
-      javaOptions in reStart <<= (javaOptions, reJRebelJar) { (jvmOptions, jrJar) =>
+      javaOptions in reStart <<= (javaOptions, reJRebelJar) map { (jvmOptions, jrJar) =>
         jvmOptions ++ createJRebelAgentOption(SysoutLogger, jrJar).toSeq
       },
 


### PR DESCRIPTION
sbt 0.12.0 support. for issue #12

key `javaOptions` type changed from sbt 0.12.0
https://github.com/harrah/xsbt/commit/c42659318b2502ee7482dae71590f8ff5296ad3c#L0L181
thus this pull request **break** compatibility of sbt 0.11.x .
I want to keep compatibility of 0.11.x but a little difficult.
Have you good idea ?
