### PR TITLE
Configurable list of process colors (issue #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ To enable debugging with the specified options:
 
     Revolver.enableDebugging(port = 5050, suspend = true)
 
+To change set of colors used to tag output from multiple processes:
+
+    Revolver.reColors := Seq("blue", "green", "magenta")
+
 ## Known issues
 
  * [#21](https://github.com/spray/sbt-revolver/issues/21): Project aggregation may lead to running processes being lost 

--- a/src/main/scala/spray/revolver/Actions.scala
+++ b/src/main/scala/spray/revolver/Actions.scala
@@ -32,16 +32,16 @@ object Actions {
     state.put(appProcessKey, state.get(appProcessKey).getOrElse(Map.empty) - project._1)
 
   def restartApp(streams: TaskStreams, state: State, project: ProjectRef, option: ForkScalaRun, mainClass: Option[String],
-                 cp: Classpath, args: Seq[String], startConfig: ExtraCmdLineOptions): (ProjectRef, AppProcess) = {
+                 cp: Classpath, args: Seq[String], startConfig: ExtraCmdLineOptions, colors: Seq[String]): (ProjectRef, AppProcess) = {
     stopAppWithStreams(streams, state, project)
-    project -> startApp(streams, unregisterAppProcess(state, (project, ())), project, option, mainClass, cp, args, startConfig)
+    project -> startApp(streams, unregisterAppProcess(state, (project, ())), project, option, mainClass, cp, args, startConfig, colors)
   }
 
   def startApp(streams: TaskStreams, state: State, project: ProjectRef, options: ForkScalaRun, mainClass: Option[String],
-               cp: Classpath, args: Seq[String], startConfig: ExtraCmdLineOptions): AppProcess = {
+               cp: Classpath, args: Seq[String], startConfig: ExtraCmdLineOptions, colors: Seq[String]): AppProcess = {
     assert(state.get(appProcessKey).flatMap(_ get project).isEmpty)
 
-    val color = Utilities.nextColor()
+    val color = Utilities.nextColor(colors)
     val logger = new SysoutLogger(project.project, color, streams.log.ansiCodesSupported)
     colorLogger(streams.log).info("[YELLOW]Starting application %s in the background ..." format formatAppName(project.project, color))
     AppProcess(project.project, color, logger) {

--- a/src/main/scala/spray/revolver/AppProcess.scala
+++ b/src/main/scala/spray/revolver/AppProcess.scala
@@ -22,7 +22,7 @@ import sbt.{Logger, Process}
 /**
  * A token which we put into the SBT state to hold the Process of an application running in the background.
  */
-case class AppProcess(projectName: String, consoleColor: String = Utilities.nextColor(), log: Logger)(process: Process) {
+case class AppProcess(projectName: String, consoleColor: String, log: Logger)(process: Process) {
   val shutdownHook = new Thread(new Runnable {
     def run() {
       if (isRunning) {

--- a/src/main/scala/spray/revolver/RevolverKeys.scala
+++ b/src/main/scala/spray/revolver/RevolverKeys.scala
@@ -35,6 +35,8 @@ trait RevolverKeys {
   val reJRebelJar = SettingKey[String]("re-jrebel-jar", "The path to the JRebel JAR. Automatically initialized to " +
     "value of the `JREBEL_PATH` environment variable.")
 
+  val reColors = SettingKey[Seq[String]]("re-colors", "Colors used for tagging output from different processes")
+
   val debugSettings = SettingKey[Option[DebugSettings]]("debug-settings", "Settings for enabling remote JDWP debugging.")
 
 }

--- a/src/main/scala/spray/revolver/RevolverPlugin.scala
+++ b/src/main/scala/spray/revolver/RevolverPlugin.scala
@@ -29,8 +29,10 @@ object RevolverPlugin extends Plugin {
 
       mainClass in reStart <<= mainClass in run in Compile,
 
+      reColors in reStart := Seq("BLUE", "MAGENTA", "CYAN", "RED", "GREEN"),
+
       reStart <<= InputTask(startArgsParser) { args =>
-        (streams, state, thisProjectRef, reForkOptions, mainClass in reStart, fullClasspath in Runtime, reStartArgs, args)
+        (streams, state, thisProjectRef, reForkOptions, mainClass in reStart, fullClasspath in Runtime, reStartArgs, args, reColors)
           .map(restartApp)
           .updateState(registerAppProcess)
           .map(_._2)

--- a/src/main/scala/spray/revolver/Utilities.scala
+++ b/src/main/scala/spray/revolver/Utilities.scala
@@ -61,10 +61,9 @@ object Utilities {
         .replace("[CYAN]", "")
         .replace("[WHITE]", "")
 
-  val colors = "BLUE MAGENTA CYAN RED GREEN".split(" ").map(_ formatted "[%s]")
   private[this] var lastColorIdx = -1
-  def nextColor(): String = {
+  def nextColor(colors: Seq[String]): String = {
     lastColorIdx = (lastColorIdx + 1) % colors.size
-    colors(lastColorIdx)
+    colors(lastColorIdx).toUpperCase formatted "[%s]"
   }
 }


### PR DESCRIPTION
This pull request enables user-configurable process colors in the following fashion:

```
Revolver.reColors := Seq("blue", "green")
```

I'm not very sure about `reColors` name, though.

I tested it with locally-published snapshot, and it seems to work as expected.
