### PR TITLE
Keys in RevolverPlugin should not be in Global

### DIFF
--- a/src/main/scala/spray/revolver/RevolverPlugin.scala
+++ b/src/main/scala/spray/revolver/RevolverPlugin.scala
@@ -42,14 +42,14 @@ object RevolverPlugin extends Plugin {
       reStatus <<= (streams, thisProjectRef) map showStatus,
 
       // default: no arguments to the app
-      reStartArgs in Global := Seq.empty,
+      reStartArgs := Seq.empty,
 
       // initialize with env variable
-      reJRebelJar in Global := Option(System.getenv("JREBEL_PATH")).getOrElse(""),
+      reJRebelJar := Option(System.getenv("JREBEL_PATH")).getOrElse(""),
 
-      debugSettings in Global := None,
+      debugSettings := None,
 
-      reLogTag in Global <<= thisProjectRef(_.project),
+      reLogTag <<= thisProjectRef(_.project),
 
       // bake JRebel activation into java options for the forked JVM
       SbtCompat.impl.changeJavaOptionsWithExtra(debugSettings in reStart) { (jvmOptions, jrJar, debug) =>


### PR DESCRIPTION
When using Revolver with an sbt build having multiple projects, the
reLogTag will be set to the same value for each project, rather than
each projects' name.

This change removes the "in Global" qualifier from the keys in
RevolverPlugin

Consider the following build:

object MyBuild extends Build {
  lazy val foo =
    Project(id = "foo", base = file("foo")).settings(Revolver.settings: _*)

  lazy val bar =
    Project(id = "bar", base = file("bar")).settings(Revolver.settings: _*)
}

Without this fix, all "reLogTag" for all projects will be the same:

> $ sbt
> Detected sbt version 0.13.0
> Starting sbt: invoke with -help for other options
> [info] Loading project definition from /home/jared/testsbt/project
> [info] Set current project to testsbt (in build file:/home/jared/testsbt/)
> show reLogTag
> [info] bar/_:reLogTag
> [info]  foo
> [info] foo/_:reLogTag
> [info]  foo
> [info] testsbt/*:reLogTag
> [info]  foo
