### PR TITLE
Remove red as a color associated with a JVM process

### DIFF
--- a/src/main/scala/spray/revolver/RevolverPlugin.scala
+++ b/src/main/scala/spray/revolver/RevolverPlugin.scala
@@ -89,7 +89,7 @@ object RevolverPlugin extends Plugin {
       debugSettings in reStart := Some(DebugSettings(port, suspend))
 
     def noColors: Seq[String] = Nil
-    def basicColors = Seq("BLUE", "MAGENTA", "CYAN", "YELLOW", "RED", "GREEN")
+    def basicColors = Seq("BLUE", "MAGENTA", "CYAN", "YELLOW", "GREEN")
     def basicColorsAndUnderlined = basicColors ++ basicColors.map("_"+_)
   }
 


### PR DESCRIPTION
Red is cognitively associated with an error message and the use of it in this context is not helping users parse sbt output in an efficient way.

Anyone have a suggestion for an alternative color to replace red?
