### PR TITLE
fix issue with JNI libraries for sbt 0.13, refs #36

### DIFF
--- a/src/main/scala-sbt-0.13/spray/revolver/SbtCompatImpl.scala
+++ b/src/main/scala-sbt-0.13/spray/revolver/SbtCompatImpl.scala
@@ -15,6 +15,6 @@ object SbtCompatImpl extends SbtCompat with RevolverKeys {
         outputStrategy = Some(config.outputStrategy getOrElse LoggedOutput(log)),
         runJVMOptions = config.runJVMOptions ++ extraJvmArgs)
 
-    Fork.scala.fork(newOptions, scalaOptions)
+    Fork.java.fork(newOptions, scalaOptions)
   }
 }

--- a/src/main/scala/spray/revolver/RevolverPlugin.scala
+++ b/src/main/scala/spray/revolver/RevolverPlugin.scala
@@ -60,12 +60,12 @@ object RevolverPlugin extends Plugin {
       },
 
       // bundles the various parameters for forking
-      reForkOptions <<= (taskTemporaryDirectory, scalaInstance, baseDirectory in reStart, javaOptions in reStart, outputStrategy,
-        javaHome) map ( (tmp, si, base, jvmOptions, strategy, javaHomeDir) =>
+      reForkOptions <<= (taskTemporaryDirectory, baseDirectory in reStart, javaOptions in reStart, outputStrategy,
+        javaHome) map ( (tmp, base, jvmOptions, strategy, javaHomeDir) =>
         ForkOptions(
           javaHomeDir,
           strategy,
-          si.jars,
+          Nil, // bootJars is empty by default because only jars on the user's classpath should be on the boot classpath
           workingDirectory = Some(base),
           runJVMOptions = jvmOptions,
           connectInput = false


### PR DESCRIPTION
Hi,

I had the same issue described in #36, since 0.13 sbt does forking a bit different, see

https://github.com/sbt/sbt/blob/473fc8476d25ef3fcbfe6b91b7ee57f1099bdf72/main/src/main/scala/sbt/Defaults.scala#L453
https://github.com/sbt/sbt/blob/9c442d3aed53bdc89db1ada9d5b204bf02adb339/run/src/main/scala/sbt/Run.scala#L26

You can verify this fix by launching any akka-persistence application with native leveldb journal.

Thanks,
Gleb