### PR TITLE
Bump up sbt; remove closed repository

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 resolvers ++= Seq(
-  "less is" at "http://repo.lessis.me",
   "coda" at "http://repo.codahale.com",
   "staging" at "https://oss.sonatype.org/content/repositories/netvirtual-void-1005"
 )


### PR DESCRIPTION
Sbt 0.12.x is somewhat old, and it doesn't work well with JDK 8 in my machine with this error:

```
error: error while loading CharSequence, class file 'C:\Program Files\Java\jdk1.8.0_51\jre\lib\rt.jar(java/lang/CharSequence.class)' is broken
(bad constant pool tag 15 at byte 1501)
[error] Type error in expression
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? q
```

Just upgrading sbt version number seems fix it.

Additionally, I removed `http://repo.lessis.me`, which is not working now. `ls-sbt` seems being hosted from another repo.