### PR TITLE
Update sbt settings enumeration format

### DIFF
--- a/src/main/scala/spray/revolver/RevolverPlugin.scala
+++ b/src/main/scala/spray/revolver/RevolverPlugin.scala
@@ -25,7 +25,7 @@ object RevolverPlugin extends Plugin {
     import Actions._
     import Utilities._
 
-    lazy val settings = seq(
+    lazy val settings = Seq(
 
       mainClass in reStart <<= mainClass in run in Compile,
 


### PR DESCRIPTION
This doesn't seem to come up when compiling from the terminal but with an IDE(like IntelliJ), using `seq` instead of `Seq` shows error:

`Expression type (Def.Settings.Definition) must conform to Setting[_] in SBT file`