### PR TITLE
reForkOptions should include envVars.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,10 @@
 sbtPlugin := true
 
 scalacOptions := Seq("-deprecation", "-encoding", "utf8")
+
+// Scripted test options.
+
+scriptedSettings
+scriptedLaunchOpts += s"-Dplugin.version=${version.value}"
+scriptedBufferLog := false
+test in Test <<= (test in Test).dependsOn(scripted.toTask(""))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+
+libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/publish.sbt
+++ b/publish.sbt
@@ -2,7 +2,7 @@ name := "sbt-revolver"
 
 organization := "io.spray"
 
-version := "0.8.0"
+version := "0.8.0-SNAPSHOT"
 
 description := "An SBT plugin for dangerously fast development turnaround in Scala"
 

--- a/src/main/scala/spray/revolver/RevolverPlugin.scala
+++ b/src/main/scala/spray/revolver/RevolverPlugin.scala
@@ -88,7 +88,8 @@ object RevolverPlugin extends AutoPlugin {
           Nil, // bootJars is empty by default because only jars on the user's classpath should be on the boot classpath
           workingDirectory = Some((baseDirectory in reStart).value),
           runJVMOptions = (javaOptions in reStart).value,
-          connectInput = false
+          connectInput = false,
+          envVars = (envVars in reStart).value
         )
       },
 

--- a/src/sbt-test/sbt-revolver/env-vars/build.sbt
+++ b/src/sbt-test/sbt-revolver/env-vars/build.sbt
@@ -1,0 +1,11 @@
+scalaVersion := "2.11.8"
+
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-actor" % "2.4.7",
+  "io.spray" %% "spray-can" % "1.3.2",
+  "io.spray" %% "spray-routing" % "1.3.2"
+)
+
+enablePlugins(RevolverPlugin)
+
+envVars in reStart += "TEST_VAR" -> "OK"

--- a/src/sbt-test/sbt-revolver/env-vars/project/plugins.sbt
+++ b/src/sbt-test/sbt-revolver/env-vars/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.spray" % "sbt-revolver" % System.getProperty("plugin.version"))

--- a/src/sbt-test/sbt-revolver/env-vars/src/main/scala/TestService.scala
+++ b/src/sbt-test/sbt-revolver/env-vars/src/main/scala/TestService.scala
@@ -1,0 +1,30 @@
+package spray.revolver.test
+
+import akka.actor.{ Actor, ActorSystem, Props }
+import akka.io.IO
+import akka.pattern.ask
+import akka.util.Timeout
+import spray.can.Http
+import spray.routing.HttpServiceActor
+
+import scala.concurrent.duration._
+
+object TestService extends App {
+  implicit val system = ActorSystem("test-system")
+  import system.dispatcher
+
+  implicit val timeout = Timeout(5.seconds)
+
+  val service = system.actorOf(Props(classOf[TestServiceActor]), "service")
+  IO(Http) ? Http.Bind(service, interface = "0.0.0.0", port = 8888)
+}
+
+class TestServiceActor extends HttpServiceActor {
+  override def receive = runRoute(route)
+
+  val route = {
+    get {
+      complete(sys.env("TEST_VAR"))
+    }
+  }
+}

--- a/src/sbt-test/sbt-revolver/env-vars/test
+++ b/src/sbt-test/sbt-revolver/env-vars/test
@@ -1,0 +1,4 @@
+> reStart
+$ sleep 2000
+$ exec curl http://0.0.0.0:8888
+> reStop


### PR DESCRIPTION
Fixes #63. Also adds SBT-scripted to test the change (LMK if you'd rather not include it).
