### PR TITLE
Updated JRebel functionality to support -agentpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following SBT settings defined by _sbt-revolver_ are of potential interest:
   what `run` assumes.
 * `re-start::full-classpath`, which lets you customize the full classpath path for running with `re-start`.
 * `re-jrebel-jar`, a `SettingKey[String]`, which lets you override the value of the `JREBEL_PATH` env variable.
+* `re-jrebel-agent`, a `SettingKey[String]`, which lets you override the value of the `JREBEL_AGENT_PATH` env variable.
 * `re-colors`, a `SettingKey[Seq[String]]`, which lets you change colors used to tag output from running processes.
   There are some pre-defined color schemes, see the example section below.
 * `re-log-tag`, a `SettingKey[String]`, which lets you change the log tag shown in front of log messages. Default is the
@@ -98,12 +99,16 @@ There are predefined color schemes to use with `reColors`: `Revolver.noColors`, 
 
 *Note: JRebel support in sbt-revolver is not actively supported any more.*
 
-If you have JRebel installed you can let _sbt-revolver_ know where to find the `jrebel.jar`. You can do this
-either via the `Revolver.jRebelJar` setting directly in your SBT config or via a shell environment variable with the
-name `JREBEL_PATH` (which is the recommended way, since it doesn't pollute your SBT config with system-specific settings).
+If you have JRebel installed you can let _sbt-revolver_ know where to find the `jrebel.jar` or the agent libraries. You can do this
+either via the `Revolver.jRebelJar`/`Revolver.jRebelAgent` setting directly in your SBT config or via a shell environment variable with the
+name `JREBEL_PATH` or `JREBEL_AGENT_PATH` (which is the recommended way, since it doesn't pollute your SBT config with system-specific settings).
 For example, on OSX you would add the following line to your shell startup script:
 
+    # if you want to use the older jrebel. jar
     export JREBEL_PATH=/Applications/ZeroTurnaround/JRebel/jrebel.jar
+
+    # or for newer JRebel versions
+    export JREBEL_AGENT_PATH=/Applications/ZeroTurnaround/JRebel/lib/libjrebel64.dylib
 
 With JRebel _sbt-revolver_ supports hot reloading:
 

--- a/src/main/scala/spray/revolver/Actions.scala
+++ b/src/main/scala/spray/revolver/Actions.scala
@@ -76,16 +76,22 @@ object Actions {
       }
     }
 
-  def createJRebelAgentOption(log: Logger, path: String): Option[String] = {
-    if (!path.trim.isEmpty) {
-      val file = new File(path)
+  def createJRebelAgentOption(log: Logger, jarPath: String, agentPath: String): Option[String] = {
+    if (!agentPath.trim.isEmpty) {
+      val file = new File(agentPath)
+      if (!file.exists || !file.isFile) {
+        log.warn("jrebel.jar: " + jarPath + " not found")
+        None
+      } else Some("-agentpath:" + file.getAbsolutePath)
+    } else if (!jarPath.trim.isEmpty) {
+      val file = new File(jarPath)
       if (!file.exists || !file.isFile) {
         val file2 = new File(file, "jrebel.jar")
         if (!file2.exists || !file2.isFile) {
-          log.warn("jrebel.jar: " + path + " not found")
+          log.warn("jrebel.jar: " + jarPath + " not found")
           None
         } else Some("-javaagent:" + file2.getAbsolutePath)
-      } else Some("-javaagent:" + path)
+      } else Some("-javaagent:" + jarPath)
     } else None
   }
 

--- a/src/main/scala/spray/revolver/Actions.scala
+++ b/src/main/scala/spray/revolver/Actions.scala
@@ -78,21 +78,31 @@ object Actions {
     }
 
   def createJRebelAgentOption(log: Logger, jarPath: String, agentPath: String): Option[String] = {
-    if (!agentPath.trim.isEmpty) {
-      val file = new File(agentPath)
+
+    def checkPath(path: String, vmOption: String, checkAgentpath: Boolean): Option[String] = {
+      val file = new File(path)
       if (!file.exists || !file.isFile) {
-        log.warn("jrebel.jar: " + jarPath + " not found")
-        None
-      } else Some("-agentpath:" + file.getAbsolutePath)
-    } else if (!jarPath.trim.isEmpty) {
-      val file = new File(jarPath)
-      if (!file.exists || !file.isFile) {
-        val file2 = new File(file, "jrebel.jar")
-        if (!file2.exists || !file2.isFile) {
-          log.warn("jrebel.jar: " + jarPath + " not found")
+        if (checkAgentpath) {
+          log.warn("jRebel agent: " + path + " not found")
           None
-        } else Some("-javaagent:" + file2.getAbsolutePath)
-      } else Some("-javaagent:" + jarPath)
+        } else {
+          val file2 = new File(path, "jrebel.jar")
+          if (!file2.exists || !file2.isFile) {
+            log.warn("jrebel.jar: " + path + " not found")
+            None
+          } else {
+            Some(vmOption + file2.getAbsolutePath)
+          }
+        }
+      } else {
+        Some(vmOption + file.getAbsolutePath)
+      }
+    }
+
+    if (!agentPath.trim.isEmpty) {
+      checkPath(agentPath.trim, "-agentpath:", true)
+    } else if (!jarPath.trim.isEmpty) {
+      checkPath(jarPath.trim, "-javaagent:", false)
     } else None
   }
 

--- a/src/main/scala/spray/revolver/RevolverKeys.scala
+++ b/src/main/scala/spray/revolver/RevolverKeys.scala
@@ -35,6 +35,9 @@ trait RevolverKeys {
   val reJRebelJar = SettingKey[String]("re-jrebel-jar", "The path to the JRebel JAR. Automatically initialized to " +
     "value of the `JREBEL_PATH` environment variable.")
 
+  val reJRebelAgent = SettingKey[String]("re-jrebel-agent", "The path to the JRebel agent lib. Automatically initialized to " +
+    "value of the `JREBEL_AGENT_PATH` environment variable.")
+
   val reColors = SettingKey[Seq[String]]("re-colors", "Colors used for tagging output from different processes")
 
   // we need this strange setup to make sure we can define a project specific default


### PR DESCRIPTION
In addition to JREBEL_PATH there is now support for JREBEL_AGENT_PATH which (if set) will result in -agentpath being used instead of -javaagent as recommended here: https://manuals.zeroturnaround.com/jrebel/standalone/launch-from-command-line.html