### PR TITLE
Use `javaHome in reStart` for reForkOptions

### DIFF
--- a/src/main/scala/spray/revolver/RevolverPlugin.scala
+++ b/src/main/scala/spray/revolver/RevolverPlugin.scala
@@ -83,7 +83,7 @@ object RevolverPlugin extends AutoPlugin {
       reForkOptions := {
         taskTemporaryDirectory.value
         ForkOptions(
-          javaHome = javaHome.value,
+          javaHome = (javaHome in reStart).value,
           outputStrategy = outputStrategy.value,
           bootJars = Vector.empty[File], // bootJars is empty by default because only jars on the user's classpath should be on the boot classpath
           workingDirectory = Option((baseDirectory in reStart).value),


### PR DESCRIPTION
There is at least at least one cryptoprovider that makes some changes to the JVM it's installed to (breaking the standard HTTPS implementation). I have to test my code with such JVM, but I don't need it doing anything else in my project.

This change allows overriding `javaHome` just for `reStart`.