### PR TITLE
Get process PID, use it to send `SIGTERM`

### DIFF
--- a/src/main/scala/scala/sys/process/ProcessWithPid.scala
+++ b/src/main/scala/scala/sys/process/ProcessWithPid.scala
@@ -1,0 +1,48 @@
+package scala.sys.process
+
+import java.lang.{Process => JProcess}
+import sbt.{Level, Logger}
+import scala.util.control.NonFatal
+
+case class ProcessWithPid(process: Process, pid: Option[Long])
+
+object ProcessWithPid {
+  private def reflectJProcess(p: Process.SimpleProcess): JProcess = {
+    val field = p.getClass.getDeclaredField("p")
+    field.setAccessible(true)
+    field.get(p).asInstanceOf[JProcess]
+  }
+
+  // Java 9+ has a `Process#pid()` method, but Java 8 and below have a private `Process#pid` field
+  // We first try to reflect on the method and then fall back to reflecting on the field
+  private def reflectJProcessPid(p: JProcess): Long =
+    try {
+      val method = classOf[JProcess].getMethod("pid")
+      method.invoke(p) match {
+        case pid: java.lang.Long => pid
+        case pid => throw new RuntimeException(s"Expected process PID ($pid) to be a Long, but it was a ${pid.getClass.getName}")
+      }
+    } catch {
+      case e: NoSuchMethodException =>
+        val field = p.getClass.getDeclaredField("pid")
+        field.setAccessible(true)
+        field.getLong(p)
+    }
+
+  def apply(process: Process, log: Logger): ProcessWithPid =
+    try {
+      process match {
+        case p: Process.SimpleProcess =>
+          val jp = reflectJProcess(p)
+          val pid = reflectJProcessPid(jp)
+          ProcessWithPid(process, Some(pid))
+
+        case p =>
+          throw new RuntimeException(s"Expected app process to be a Process.SimpleProcess but it was a ${p.getClass.getName}")
+      }
+    } catch {
+      case NonFatal(e) =>
+        log.log(Level.Warn, s"Failed to determine process PID: $e")
+        ProcessWithPid(process, None)
+    }
+}

--- a/src/main/scala/spray/revolver/Actions.scala
+++ b/src/main/scala/spray/revolver/Actions.scala
@@ -19,7 +19,7 @@ package spray.revolver
 import sbt.Keys._
 import sbt.{Fork, ForkOptions, LoggedOutput, Logger, Path, ProjectRef, State, complete}
 import java.io.File
-import scala.sys.process.Process
+import scala.sys.process.ProcessWithPid
 
 object Actions {
   import Utilities._
@@ -129,13 +129,13 @@ object Actions {
   def formatAppName(projectName: String, projectColor: String, color: String = "[YELLOW]"): String =
     "[RESET]%s%s[RESET]%s" format (projectColor, projectName, color)
 
-  def forkRun(config: ForkOptions, mainClass: String, classpath: Seq[File], options: Seq[String], log: Logger, extraJvmArgs: Seq[String]): Process = {
+  def forkRun(config: ForkOptions, mainClass: String, classpath: Seq[File], options: Seq[String], log: Logger, extraJvmArgs: Seq[String]): ProcessWithPid = {
     log.info(options.mkString("Starting " + mainClass + ".main(", ", ", ")"))
     val scalaOptions = "-classpath" :: Path.makeString(classpath) :: mainClass :: options.toList
     val newOptions = config
       .withOutputStrategy(config.outputStrategy getOrElse LoggedOutput(log))
       .withRunJVMOptions(config.runJVMOptions ++ extraJvmArgs)
 
-    Fork.java.fork(newOptions, scalaOptions)
+    ProcessWithPid(Fork.java.fork(newOptions, scalaOptions), log)
   }
 }


### PR DESCRIPTION
Fixes #20 

Updates `AppProcess` to hold onto a `ProcessWithPid`, which is a new type defined in the `scala.sys.process` package. Given a standard `Process`, the `ProcessWithPid.apply` method will do its best to get the PID of the `Process`.

Unfortunately the only way to do so is via reflection. We first have to reflect on the private `scala.sys.Process.SimpleProcess#p` field to get the underlying `java.lang.Process`. We then try to call the [`java.lang.Process#pid()` method](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Process.html#pid()), which exists in Java 9 and above. If that fails with a `NoSuchMethodException`, then we fall back to looking at the private `java.lang.ProcessImpl#pid` field, which works in Java 8 and below.

When a PID is discovered, `AppProcess` uses it to send a `kill -15 <pid>` to the process. It will wait 10 seconds for the process to exit before forcibly killing it with `process.destroy()`.

When we fail to discover a PID for any reason, `AppProcess` will just forcibly kill the process with `process.destroy()`, as it currently does.