### PR TITLE
Cross build for sbt 2.0.0-RC6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,17 @@
+lazy val scala212 = "2.12.20"
+lazy val scala3 = "3.6.3"
+
+scalaVersion := scala212
+crossScalaVersions := Seq(scala212, scala3)
+
 enablePlugins(SbtPlugin)
+
+pluginCrossBuild / sbtVersion := {
+  scalaBinaryVersion.value match {
+    case "2.12" => "1.8.2"
+    case _ => "2.0.0-M3"
+  }
+}
 
 scalacOptions := Seq("-deprecation", "-encoding", "utf8")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.10.7

--- a/src/main/scala-2/spray/revolver/RevolverPluginCompat.scala
+++ b/src/main/scala-2/spray/revolver/RevolverPluginCompat.scala
@@ -1,0 +1,10 @@
+package spray.revolver
+
+import sbt._
+import sbt.Keys._
+
+trait RevolverPluginCompat {
+  val reStartClasspathFilesTask = Def.task {
+    (Runtime / fullClasspath).value.map(_.data)
+  }
+}

--- a/src/main/scala-3/spray/revolver/RevolverPluginCompat.scala
+++ b/src/main/scala-3/spray/revolver/RevolverPluginCompat.scala
@@ -1,0 +1,11 @@
+package spray.revolver
+
+import sbt._
+import sbt.Keys._
+
+trait RevolverPluginCompat {
+  val reStartClasspathFilesTask = Def.task {
+    val conv = fileConverter.value
+    (Runtime / fullClasspath).value.map(f => conv.toPath(f.data).toFile)
+  }
+}

--- a/src/main/scala/spray/revolver/Actions.scala
+++ b/src/main/scala/spray/revolver/Actions.scala
@@ -25,13 +25,13 @@ object Actions {
   import Utilities._
 
   def restartApp(streams: TaskStreams, logTag: String, project: ProjectRef, option: ForkOptions, mainClass: Option[String],
-                 cp: Classpath, args: Seq[String], startConfig: ExtraCmdLineOptions): AppProcess = {
+                 cp: Seq[File], args: Seq[String], startConfig: ExtraCmdLineOptions): AppProcess = {
     stopAppWithStreams(streams, project)
     startApp(streams, logTag, project, option, mainClass, cp, args, startConfig)
   }
 
   def startApp(streams: TaskStreams, logTag: String, project: ProjectRef, options: ForkOptions, mainClass: Option[String],
-               cp: Classpath, args: Seq[String], startConfig: ExtraCmdLineOptions): AppProcess = {
+               cp: Seq[File], args: Seq[String], startConfig: ExtraCmdLineOptions): AppProcess = {
     assert(!revolverState.getProcess(project).exists(_.isRunning))
 
     // fail early
@@ -42,7 +42,7 @@ object Actions {
 
     val appProcess=
       AppProcess(project, color, logger) {
-        forkRun(options, theMainClass, cp.map(_.data), args ++ startConfig.startArgs, logger, startConfig.jvmArgs)
+        forkRun(options, theMainClass, cp, args ++ startConfig.startArgs, logger, startConfig.jvmArgs)
       }
     registerAppProcess(project, appProcess)
     appProcess

--- a/src/main/scala/spray/revolver/AppProcess.scala
+++ b/src/main/scala/spray/revolver/AppProcess.scala
@@ -29,7 +29,7 @@ case class AppProcess(projectRef: ProjectRef, consoleColor: String, log: Logger)
 
   def createShutdownHook(msg: => String) =
     new Thread(new Runnable {
-      def run() {
+      def run(): Unit = {
         if (isRunning) {
           log.info(msg)
           process.destroy()
@@ -41,7 +41,7 @@ case class AppProcess(projectRef: ProjectRef, consoleColor: String, log: Logger)
 
   val watchThread = {
     val thread = new Thread(new Runnable {
-      def run() {
+      def run(): Unit = {
         val code = process.exitValue()
         finishState = Some(code)
         log.info("... finished with exit code %d" format code)
@@ -56,17 +56,17 @@ case class AppProcess(projectRef: ProjectRef, consoleColor: String, log: Logger)
 
   registerShutdownHook()
 
-  def stop() {
+  def stop(): Unit = {
     unregisterShutdownHook()
     process.destroy()
     process.exitValue()
   }
 
-  def registerShutdownHook() {
+  def registerShutdownHook(): Unit = {
     JRuntime.getRuntime.addShutdownHook(shutdownHook)
   }
 
-  def unregisterShutdownHook() {
+  def unregisterShutdownHook(): Unit = {
     JRuntime.getRuntime.removeShutdownHook(shutdownHook)
   }
 

--- a/src/main/scala/spray/revolver/RevolverKeys.scala
+++ b/src/main/scala/spray/revolver/RevolverKeys.scala
@@ -41,7 +41,7 @@ trait RevolverKeys {
   // we cannot put the project specific one `in Global` as it isn't Global
   val reLogTagUnscoped = SettingKey[String]("re-log-tag", "The tag used in front of log messages for this project")
   // users should set this one, while we put the default into the unscoped variant
-  val reLogTag = reLogTagUnscoped in reStart
+  val reLogTag = reStart / reLogTagUnscoped
 
   val debugSettings = SettingKey[Option[DebugSettings]]("debug-settings", "Settings for enabling remote JDWP debugging.")
 

--- a/src/main/scala/spray/revolver/RevolverPlugin.scala
+++ b/src/main/scala/spray/revolver/RevolverPlugin.scala
@@ -20,7 +20,7 @@ import sbt._
 import sbt.Keys._
 import Actions._
 import Utilities._
-object RevolverPlugin extends AutoPlugin {
+object RevolverPlugin extends AutoPlugin with RevolverPluginCompat {
 
   object autoImport extends RevolverKeys {
     object Revolver {
@@ -38,6 +38,8 @@ object RevolverPlugin extends AutoPlugin {
   }
   import autoImport._
 
+  lazy val reStartClasspathFiles = taskKey[Seq[File]]("reStart classpath files")
+
   lazy val settings = Seq(
 
     reStart / mainClass := (Compile / run / mainClass).value,
@@ -46,6 +48,8 @@ object RevolverPlugin extends AutoPlugin {
 
     Global / reStart / reColors := Revolver.basicColors,
 
+    reStartClasspathFiles := reStartClasspathFilesTask.value,
+
     reStart := Def.inputTask{
       restartApp(
         streams.value,
@@ -53,7 +57,7 @@ object RevolverPlugin extends AutoPlugin {
         thisProjectRef.value,
         reForkOptions.value,
         (reStart / mainClass).value,
-        (reStart / fullClasspath).value,
+        reStartClasspathFiles.value,
         reStartArgs.value,
         startArgsParser.parsed
       )

--- a/src/main/scala/spray/revolver/RevolverState.scala
+++ b/src/main/scala/spray/revolver/RevolverState.scala
@@ -7,7 +7,7 @@ import scala.collection.immutable.Queue
 
 case class RevolverState(processes: Map[ProjectRef, AppProcess], colorPool: Queue[String]) {
   def addProcess(project: ProjectRef, process: AppProcess): RevolverState = copy(processes = processes + (project -> process))
-  private[this] def removeProcess(project: ProjectRef): RevolverState = copy(processes = processes - project)
+  private def removeProcess(project: ProjectRef): RevolverState = copy(processes = processes - project)
   def removeProcessAndColor(project: ProjectRef): RevolverState =
     getProcess(project) match {
       case Some(process) => removeProcess(project).offerColor(process.consoleColor)
@@ -38,7 +38,7 @@ object RevolverState {
  * state when doing several updates depending on another.
  */
 object GlobalState {
-  private[this] val state = new AtomicReference(RevolverState.initial)
+  private val state = new AtomicReference(RevolverState.initial)
 
   @tailrec def update(f: RevolverState => RevolverState): RevolverState = {
     val originalState = state.get()

--- a/src/main/scala/spray/revolver/SysoutLogger.scala
+++ b/src/main/scala/spray/revolver/SysoutLogger.scala
@@ -23,16 +23,16 @@ import sbt._
  */
 class SysoutLogger(appName: String, color: String, ansiCodesSupported: Boolean = false) extends Logger {
 
-  def trace(t: => Throwable) {
+  def trace(t: => Throwable): Unit = {
     t.printStackTrace()
     println(t)
   }
 
-  def success(message: => String) {
+  def success(message: => String): Unit = {
     println(Utilities.colorize(ansiCodesSupported, "%s%s[RESET] success: " format (color, appName)) + message)
   }
 
-  def log(level: Level.Value, message: => String) {
+  def log(level: Level.Value, message: => String): Unit = {
     val levelStr = level match {
       case Level.Info => ""
       case Level.Error => "[ERROR]"

--- a/src/main/scala/spray/revolver/Utilities.scala
+++ b/src/main/scala/spray/revolver/Utilities.scala
@@ -23,8 +23,8 @@ object Utilities {
   def colorLogger(state: State): Logger = colorLogger(state.log)
 
   def colorLogger(logger: Logger): Logger = new Logger {
-    def trace(t: => Throwable) { logger.trace(t) }
-    def success(message: => String) { success(message) }
+    def trace(t: => Throwable): Unit = { logger.trace(t) }
+    def success(message: => String): Unit = { success(message) }
     def log(level: Level.Value, message: => String): Unit =
       logger.log(level, colorize(logger.ansiCodesSupported, message))
   }

--- a/src/main/scala/spray/revolver/Utilities.scala
+++ b/src/main/scala/spray/revolver/Utilities.scala
@@ -24,7 +24,7 @@ object Utilities {
 
   def colorLogger(logger: Logger): Logger = new Logger {
     def trace(t: => Throwable): Unit = { logger.trace(t) }
-    def success(message: => String): Unit = { success(message) }
+    def success(message: => String): Unit = { logger.success(message) }
     def log(level: Level.Value, message: => String): Unit =
       logger.log(level, colorize(logger.ansiCodesSupported, message))
   }

--- a/src/sbt-test/sbt-revolver/env-vars/build.sbt
+++ b/src/sbt-test/sbt-revolver/env-vars/build.sbt
@@ -8,4 +8,4 @@ libraryDependencies ++= Seq(
 
 enablePlugins(RevolverPlugin)
 
-envVars in reStart += "TEST_VAR" -> "OK"
+reStart / envVars += "TEST_VAR" -> "OK"


### PR DESCRIPTION
Due to whitespace changes in `RevolverPlugin.scala` this is best viewed with whitespace ignored: https://github.com/spray/sbt-revolver/pull/121/files?w=1

- Updates sbt build to cross-build against Scala 2.12.20 (sbt 1) and Scala 3.7.3 (sbt 2)
- Migrates to slash syntax
- Fixes procedure syntax and extra indentation, which triggers warnings in Scala 3
- Fixes infinite recursion in `Utilities.colorLogger`
- Removes switching on `ansiCodesSupported` -- it doesn't exist in sbt 2 and as far as I can tell isn't necessary to suppress colors when using sbt's `Logger`